### PR TITLE
OPS-2684 New outputs: consul/vault instance ids and private ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ module "aws_vault" {
 | elb_route53_public_dns_name_vault | The Route53 name attached to the Vault ELB, if spcified in variables. |
 | asg_name_consul_cluster | Autoscaling group name of the Consul cluster. |
 | asg_name_vault_cluster | Autoscaling group name of the Vault cluster. |
+| consul_instance_ids | List of EC2 instance ids of deployed consul hosts |
+| vault_instance_ids | List of EC2 instance ids of deployed vault hosts |
+| consul_private_ips | List of private IPs of deployed consul hosts |
+| vault_private_ips | List of private IPs of deployed vault hosts |
 | launch_config_name_consul_cluster | Launch configuration name of the Consul cluster. |
 | launch_config_name_vault_cluster | Launch configuration name of the Vault cluster. |
 | iam_role_arn_consul_cluster | IAM role ARN attached to the Consul cluster. |

--- a/main.tf
+++ b/main.tf
@@ -197,3 +197,20 @@ data "template_file" "user_data_consul" {
     ssh_user                 = "ubuntu"
   }
 }
+
+# -------------------------------------------------------------------------------------------------
+# Data sources required for outputs
+# -------------------------------------------------------------------------------------------------
+data "aws_instances" "consul" {
+  filter {
+    name   = "tag:Name"
+    values = ["${var.consul_cluster_name}"]
+  }
+}
+
+data "aws_instances" "vault" {
+  filter {
+    name   = "tag:Name"
+    values = ["${var.vault_cluster_name}"]
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,20 +28,6 @@ output "asg_name_vault_cluster" {
 # EC2
 # -------------------------------------------------------------------------------------------------
 
-data "aws_instances" "consul" {
-  filter {
-    name   = "tag:Name"
-    values = ["${var.consul_cluster_name}"]
-  }
-}
-
-data "aws_instances" "vault" {
-  filter {
-    name   = "tag:Name"
-    values = ["${var.vault_cluster_name}"]
-  }
-}
-
 output "consul_instance_ids" {
   description = "List of EC2 instance ids of deployed consul hosts"
   value       = ["${data.aws_instances.consul.ids}"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,6 +25,44 @@ output "asg_name_vault_cluster" {
 }
 
 # -------------------------------------------------------------------------------------------------
+# EC2
+# -------------------------------------------------------------------------------------------------
+
+data "aws_instances" "consul" {
+  filter {
+    name   = "tag:Name"
+    values = ["${var.consul_cluster_name}"]
+  }
+}
+
+data "aws_instances" "vault" {
+  filter {
+    name   = "tag:Name"
+    values = ["${var.vault_cluster_name}"]
+  }
+}
+
+output "consul_instance_ids" {
+  description = "List of EC2 instance ids of deployed consul hosts"
+  value       = ["${data.aws_instances.consul.ids}"]
+}
+
+output "vault_instance_ids" {
+  description = "List of EC2 instance ids of deployed vault hosts"
+  value       = ["${data.aws_instances.vault.ids}"]
+}
+
+output "consul_private_ips" {
+  description = "List of private IPs of deployed consul hosts"
+  value       = ["${data.aws_instances.consul.private_ips}"]
+}
+
+output "vault_private_ips" {
+  description = "List of private IPs of deployed vault hosts"
+  value       = ["${data.aws_instances.vault.private_ips}"]
+}
+
+# -------------------------------------------------------------------------------------------------
 # Launch Configuration
 # -------------------------------------------------------------------------------------------------
 output "launch_config_name_consul_cluster" {


### PR DESCRIPTION
# New outputs

This PR adds additional outputs to the module:

| Output | Description |
|--|--|
| consul_instance_ids | List of EC2 instance ids of deployed consul hosts |
| vault_instance_ids | List of EC2 instance ids of deployed vault hosts |
| consul_private_ips | List of private IPs of deployed consul hosts |
| vault_private_ips | List of private IPs of deployed vault hosts |

## Tagging

After merge, tag with `v0.2.0`