### PR TITLE
OPS-2684 be able to use S3 as a persistent storage backend for Vault

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,10 @@ module "vault_cluster" {
   vpc_id     = "${var.vpc_id}"
   subnet_ids = "${var.private_subnet_ids}"
 
+  # Use S3 Storage Backend?
+  enable_s3_backend = "${var.enable_s3_backend}"
+  s3_bucket_name    = "${var.s3_bucket_name}"
+
   # Do NOT use the ELB for the ASG health check, or the ASG will assume all sealed instances are
   # unhealthy and repeatedly try to redeploy them.
   # The ELB health check does not work on unsealed Vault instances.
@@ -97,7 +101,9 @@ data "template_file" "user_data_vault_cluster" {
   template = "${file("${path.module}/user-data-vault.sh")}"
 
   vars {
-    aws_region               = "${data.aws_region.current.name}"
+    enable_s3_backend        = "${var.enable_s3_backend ? 1 : 0}"
+    s3_bucket_region         = "${data.aws_region.current.name}"
+    s3_bucket_name           = "${var.s3_bucket_name}"
     consul_cluster_tag_key   = "${local.consul_cluster_tag_key}"
     consul_cluster_tag_value = "${local.consul_cluster_tag_val}"
     ssh_keys                 = "${join("\n", "${var.ssh_keys}")}"

--- a/modules/vault-cluster/README.md
+++ b/modules/vault-cluster/README.md
@@ -29,17 +29,13 @@ into a single 'aws_security_group' block.
 | wait_for_capacity_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior. | string | `10m` | no |
 | health_check_type | Controls how health checking is done. Must be one of EC2 or ELB. | string | `EC2` | no |
 | health_check_grace_period | Time, in seconds, after instance comes into service before checking health. | string | `60` | no |
-| instance_profile_path | Path in which to create the IAM instance profile. | string | `/` | no |
 | elb_security_group_id | ID of the security group of a public ELB from which you can API access the Vault instances. | string | - | yes |
 | ssh_security_group_id | ID of the security group of a bastion ssh instance from where you can ssh into the Vault instances. | string | - | yes |
 | consul_security_group_id | ID of the security group of the Consul instances to allow traffic from Consul into Vault. | string | - | yes |
 | cluster_name | The name of the Vault cluster (e.g. vault-stage). This variable is used to namespace all resources created by this module. | string | - | yes |
 | tags | Tags to attach to all AWS resources | map | `<map>` | no |
 | enable_s3_backend | Whether to configure an S3 storage backend in addition to Consul. | string | `false` | no |
-| s3_bucket_name | The name of the S3 bucket to create and use as a storage backend. Only used if 'enable_s3_backend' is set to true. | string | `` | no |
-| force_destroy_s3_bucket | If 'configure_s3_backend' is enabled and you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage. You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves. Only used if 'enable_s3_backend' is set to true. | string | `false` | no |
-| enable_auto_unseal | (Vault Enterprise only) Emable auto unseal of the Vault cluster | string | `false` | no |
-| auto_unseal_kms_key_arn | (Vault Enterprise only) The arn of the KMS key used for unsealing the Vault cluster | string | `` | no |
+| s3_bucket_name | The name of the S3 bucket in the same region to use as a storage backend. Only used if 'enable_s3_backend' is set to true. | string | `` | no |
 
 ## Outputs
 

--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -34,6 +34,6 @@ output "security_group_id" {
 }
 
 output "s3_bucket_arn" {
-  value       = "${join(",", aws_s3_bucket.vault_storage.*.arn)}"
+  value       = "${join(",", data.aws_s3_bucket.vault_storage.*.arn)}"
   description = "ARN of the S3 bucket if used as storage backend"
 }

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -82,11 +82,6 @@ variable "health_check_grace_period" {
   default     = 60
 }
 
-variable "instance_profile_path" {
-  description = "Path in which to create the IAM instance profile."
-  default     = "/"
-}
-
 # -------------------------------------------------------------------------------------------------
 # Security groups (required)
 # -------------------------------------------------------------------------------------------------
@@ -127,24 +122,6 @@ variable "enable_s3_backend" {
 }
 
 variable "s3_bucket_name" {
-  description = "The name of the S3 bucket to create and use as a storage backend. Only used if 'enable_s3_backend' is set to true."
-  default     = ""
-}
-
-variable "force_destroy_s3_bucket" {
-  description = "If 'configure_s3_backend' is enabled and you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage. You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves. Only used if 'enable_s3_backend' is set to true."
-  default     = false
-}
-
-# -------------------------------------------------------------------------------------------------
-# Vault Enterprise: Auto-unseal (optional)
-# -------------------------------------------------------------------------------------------------
-variable "enable_auto_unseal" {
-  description = "(Vault Enterprise only) Emable auto unseal of the Vault cluster"
-  default     = false
-}
-
-variable "auto_unseal_kms_key_arn" {
-  description = "(Vault Enterprise only) The arn of the KMS key used for unsealing the Vault cluster"
+  description = "The name of the S3 bucket in the same region to use as a storage backend. Only used if 'enable_s3_backend' is set to true."
   default     = ""
 }

--- a/user-data-consul.sh
+++ b/user-data-consul.sh
@@ -1,19 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is meant to be run in the User Data of each EC2 Instance while it's booting. The script uses the
 # run-consul script to configure and start Consul in server mode. Note that this script assumes it's running in an AMI
 # built from the Packer template in examples/vault-consul-ami/vault-consul.json.
 
+# Be picky
 set -e
 set -x
+
+# Send the log output from this script to user-data.log, syslog, and the console
+# From: https://alestic.com/2010/12/ec2-user-data-output/
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 # Add SSH keys
 printf "${ssh_keys}\n" > "/home/${ssh_user}/.ssh/authorized_keys"
 chmod 600 "/home/${ssh_user}/.ssh/authorized_keys"
 chown ${ssh_user}:${ssh_user} "/home/${ssh_user}/.ssh/authorized_keys"
-
-# Send the log output from this script to user-data.log, syslog, and the console
-# From: https://alestic.com/2010/12/ec2-user-data-output/
-exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 # These variables are passed in via Terraform template interpolation
 /opt/consul/bin/run-consul --server --cluster-tag-key "${consul_cluster_tag_key}" --cluster-tag-value "${consul_cluster_tag_value}"

--- a/user-data-vault.sh
+++ b/user-data-vault.sh
@@ -1,25 +1,43 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is meant to be run in the User Data of each EC2 Instance while it's booting. The script uses the
 # run-consul script to configure and start Consul in client mode and then the run-vault script to configure and start
 # Vault in server mode. Note that this script assumes it's running in an AMI built from the Packer template in
 # examples/vault-consul-ami/vault-consul.json.
 
+# Be picky
 set -e
 set -x
+
+# Send the log output from this script to user-data.log, syslog, and the console
+# From: https://alestic.com/2010/12/ec2-user-data-output/
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 # Add SSH keys
 printf "${ssh_keys}\n" > "/home/${ssh_user}/.ssh/authorized_keys"
 chmod 600 "/home/${ssh_user}/.ssh/authorized_keys"
 chown ${ssh_user}:${ssh_user} "/home/${ssh_user}/.ssh/authorized_keys"
 
-# Send the log output from this script to user-data.log, syslog, and the console
-# From: https://alestic.com/2010/12/ec2-user-data-output/
-exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-
 # The Packer template puts the TLS certs in these file paths
 readonly VAULT_TLS_CERT_FILE="/opt/vault/tls/vault.crt.pem"
 readonly VAULT_TLS_KEY_FILE="/opt/vault/tls/vault.key.pem"
 
-# The cluster_tag variables below are filled in via Terraform interpolation
-/opt/consul/bin/run-consul --client --cluster-tag-key "${consul_cluster_tag_key}" --cluster-tag-value "${consul_cluster_tag_value}"
-/opt/vault/bin/run-vault --tls-cert-file "$VAULT_TLS_CERT_FILE"  --tls-key-file "$VAULT_TLS_KEY_FILE"
+# Start Consul Client for auto-discovery
+/opt/consul/bin/run-consul \
+	--client \
+	--cluster-tag-key "${consul_cluster_tag_key}" \
+	--cluster-tag-value "${consul_cluster_tag_value}"
+
+# Start Vault Server
+if [ "${enable_s3_backend}" -eq "1" ]; then
+	# Use S3 as storage backend
+	/opt/vault/bin/run-vault \
+		--tls-cert-file "$VAULT_TLS_CERT_FILE" \
+		--tls-key-file "$VAULT_TLS_KEY_FILE" \
+		--enable-s3-backend --s3-bucket "${s3_bucket_name}" \
+		--s3-bucket-region "${s3_bucket_region}"
+else
+	# Use Consul as storage backend
+	/opt/vault/bin/run-vault \
+		--tls-cert-file "$VAULT_TLS_CERT_FILE" \
+		--tls-key-file "$VAULT_TLS_KEY_FILE"
+fi

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,16 @@ variable "vault_ingress_cidr_https" {
   type        = "list"
   default     = ["0.0.0.0/0"]
 }
+
+# -------------------------------------------------------------------------------------------------
+# S3 backend (optional)
+# -------------------------------------------------------------------------------------------------
+variable "enable_s3_backend" {
+  description = "Whether to configure an S3 storage backend in the same region in addition to Consul."
+  default     = false
+}
+
+variable "s3_bucket_name" {
+  description = "The name of the S3 bucket in the same region to use as a storage backend. Only used if 'enable_s3_backend' is set to true."
+  default     = ""
+}


### PR DESCRIPTION
# S3 storage backend for Vault

This PR adds the option to use S3 as a persistent storage backend for HashiCorp Vault.
The actual S3 bucket creation is not part of this module, as it should be created in a different module to not interfere at all with Vault creation/destruction.

This way we can actually completely destroy the whole HashiCorp Vault infrastructure (VPC, DNS, Consul and Vault) and re-provision it afterwards without loosing any data.

## Note for reviewers

~~This PR should be reviewerd after: https://github.com/Flaconi/terraform-aws-vault/pull/2~~

## Tagging

Once this PR is approved and merged, it should be tagged with ~~`v0.3.0`~~ `v0.2.0`. ~~Again, first merge the other PR: https://github.com/Flaconi/terraform-aws-vault/pull/2 (which is `v0.2.0`)~~