### PR TITLE
OPS-2684 Ensure example works out of the box

### DIFF
--- a/examples/custom-vpc-with-vault/README.md
+++ b/examples/custom-vpc-with-vault/README.md
@@ -1,7 +1,7 @@
 # Custom VPC with HashiCorp Vault
 
-This example deploys a custom VPC with a bastion host behind an ELB (including a Route53 DNS record)
-and a Vault cluster behind an ELB (including a Route53 DNS record).
+This example deploys a custom VPC with a bastion host behind an ELB and a Vault cluster behind an
+ELB.
 
 Custom SSH keys can be specified for each of the EC2 instances.
 
@@ -22,16 +22,6 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| region | The AWS region this module is strictly bound to. | string | - | yes |
-| allowed_account_ids | The AWS account id to which this project is strictly bound. | list | - | yes |
-| bastion_ingress_cidr_ssh | List of CIDR's from which you are allowed to ssh into the bastion host. | list | - | yes |
-| vault_ingress_cidr_https | List of CIDR's from which you are allowed to https access the vault cluster. | list | - | yes |
-| vpc_cidr | The VPC CIDR to use for this VPC. | string | - | yes |
-| vpc_subnet_azs | A list of AZ's to use to spawn subnets over | list | - | yes |
-| vpc_private_subnets | A list of private subnet CIDR's | list | - | yes |
-| vpc_public_subnets | A list of public subnet CIDR's | list | - | yes |
-| vpc_enable_nat_gateway | A boolean that enables or disables NAT gateways for private subnets | string | - | yes |
-| vpc_enable_vpn_gateway | A boolean that enables or disables a VPN gateways for the VPC | string | - | yes |
 | name | The name(-prefix) tag to apply to all AWS resources | string | `vault` | no |
 | tags | A map of additional tags to apply to all AWS resources | map | `<map>` | no |
 | vpc_tags | A map of additional tags to apply to the VPC | map | `<map>` | no |
@@ -42,7 +32,6 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | vault_cluster_name | What to name the Vault server cluster and all of its associated resources | string | `vault-vault` | no |
 | bastion_route53_public_dns_name | The Route53 public DNS name for the vault ELB. If not set, no Route53 record will be created. | string | `` | no |
 | vault_route53_public_dns_name | The Route53 public DNS name for the vault ELB. If not set, no Route53 record will be created. | string | `` | no |
-| ssh_keys | A list of public ssh keys to add to authorized_keys files. | list | - | yes |
 | bastion_instance_type | The type of EC2 Instance to run in the Bastion ASG | string | `t2.micro` | no |
 | consul_instance_type | The type of EC2 Instance to run in the Consul ASG | string | `t2.micro` | no |
 | vault_instance_type | The type of EC2 Instance to run in the Vault ASG | string | `t2.micro` | no |
@@ -58,4 +47,3 @@ Note that this example may create resources which can cost money (AWS Elastic IP
 | elb_fqdn_vault | AWS generated CNAME for the vault ELB |
 | elb_route53_public_dns_name_bastion | Route53 public DNS name for the bastion host ELB |
 | elb_route53_public_dns_name_vault | Route53 public DNS name for the vault ELB |
-

--- a/examples/custom-vpc-with-vault/main.tf
+++ b/examples/custom-vpc-with-vault/main.tf
@@ -5,31 +5,20 @@ module "aws_vpc" {
   source = "github.com/Flaconi/terraform-modules-vpc?ref=v0.1.0"
 
   # VPC Definition
-  vpc_cidr               = "${var.vpc_cidr}"
-  vpc_subnet_azs         = "${var.vpc_subnet_azs}"
-  vpc_private_subnets    = "${var.vpc_private_subnets}"
-  vpc_public_subnets     = "${var.vpc_public_subnets}"
-  vpc_enable_nat_gateway = "${var.vpc_enable_nat_gateway}"
-  vpc_enable_vpn_gateway = "${var.vpc_enable_vpn_gateway}"
+  vpc_cidr               = "40.10.0.0/16"
+  vpc_subnet_azs         = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]
+  vpc_private_subnets    = ["40.10.10.0/24", "40.10.11.0/24", "40.10.12.0/24"]
+  vpc_public_subnets     = ["40.10.20.0/24", "40.10.21.0/24", "40.10.12.0/24"]
+  vpc_enable_nat_gateway = true
+  vpc_enable_vpn_gateway = false
 
   # Resource Naming/Tagging
-  name                = "${var.name}"
-  bastion_name        = "${var.bastion_cluster_name}"
-  tags                = "${var.tags}"
-  vpc_tags            = "${var.vpc_tags}"
-  public_subnet_tags  = "${var.public_subnet_tags}"
-  private_subnet_tags = "${var.private_subnet_tags}"
-
-  # Bastion DNS
-  bastion_route53_public_dns_name = "${var.bastion_route53_public_dns_name}"
+  name         = "vault-example"
+  bastion_name = "vault-example-bastion"
 
   # Bastion SSH
-  bastion_ssh_keys        = "${var.ssh_keys}"
-  bastion_ssh_cidr_blocks = "${var.bastion_ingress_cidr_ssh}"
-
-  # Bastion Size & Type
-  bastion_cluster_size  = "${var.bastion_cluster_size}"
-  bastion_instance_type = "${var.bastion_instance_type}"
+  bastion_ssh_keys        = ["ssh-ed25519 AAAAC3Nznte5aaCdi1a1Lzaai/tX6Mc2E+S6g3lrClL09iBZ5cW2OZdSIqomcMko 2 mysshkey"]
+  bastion_ssh_cidr_blocks = ["0.0.0.0/0"]
 }
 
 # -------------------------------------------------------------------------------------------------
@@ -44,22 +33,12 @@ module "aws_vault" {
   private_subnet_ids = "${module.aws_vpc.private_subnets}"
 
   # Resource Naming/Tagging
-  name                = "${var.name}"
-  tags                = "${var.tags}"
-  consul_cluster_name = "${var.consul_cluster_name}"
-  vault_cluster_name  = "${var.vault_cluster_name}"
-
-  # Vault DNS
-  vault_route53_public_dns_name = "${var.vault_route53_public_dns_name}"
-
-  # Instance size & count
-  consul_instance_type = "${var.consul_instance_type}"
-  vault_instance_type  = "${var.vault_instance_type}"
-  consul_cluster_size  = "${var.consul_cluster_size}"
-  vault_cluster_size   = "${var.vault_cluster_size}"
+  name                = "vault-example"
+  consul_cluster_name = "vault-example-consul"
+  vault_cluster_name  = "vault-example-vault"
 
   # Security
-  ssh_keys                 = "${var.ssh_keys}"
+  ssh_keys                 = ["ssh-ed25519 AAAAC3Nznte5aaCdi1a1Lzaai/tX6Mc2E+S6g3lrClL09iBZ5cW2OZdSIqomcMko 2 mysshkey"]
   ssh_security_group_id    = "${module.aws_vpc.bastion_security_group_id}"
-  vault_ingress_cidr_https = "${var.vault_ingress_cidr_https}"
+  vault_ingress_cidr_https = ["0.0.0.0/0"]
 }

--- a/examples/custom-vpc-with-vault/variables.tf
+++ b/examples/custom-vpc-with-vault/variables.tf
@@ -1,59 +1,4 @@
 # -------------------------------------------------------------------------------------------------
-# AWS Provider (required)
-# -------------------------------------------------------------------------------------------------
-variable "region" {
-  description = "The AWS region this module is strictly bound to."
-}
-
-variable "allowed_account_ids" {
-  description = "The AWS account id to which this project is strictly bound."
-  type        = "list"
-}
-
-# -------------------------------------------------------------------------------------------------
-# Security (required)
-# -------------------------------------------------------------------------------------------------
-variable "bastion_ingress_cidr_ssh" {
-  description = "List of CIDR's from which you are allowed to ssh into the bastion host."
-  type        = "list"
-}
-
-variable "vault_ingress_cidr_https" {
-  description = "List of CIDR's from which you are allowed to https access the vault cluster."
-  type        = "list"
-}
-
-# -------------------------------------------------------------------------------------------------
-# VPC (required)
-# -------------------------------------------------------------------------------------------------
-variable "vpc_cidr" {
-  description = "The VPC CIDR to use for this VPC."
-}
-
-variable "vpc_subnet_azs" {
-  description = "A list of AZ's to use to spawn subnets over"
-  type        = "list"
-}
-
-variable "vpc_private_subnets" {
-  description = "A list of private subnet CIDR's"
-  type        = "list"
-}
-
-variable "vpc_public_subnets" {
-  description = "A list of public subnet CIDR's"
-  type        = "list"
-}
-
-variable "vpc_enable_nat_gateway" {
-  description = "A boolean that enables or disables NAT gateways for private subnets"
-}
-
-variable "vpc_enable_vpn_gateway" {
-  description = "A boolean that enables or disables a VPN gateways for the VPC"
-}
-
-# -------------------------------------------------------------------------------------------------
 # Resource Naming/Tagging (optional)
 # -------------------------------------------------------------------------------------------------
 variable "name" {
@@ -117,14 +62,6 @@ variable "bastion_route53_public_dns_name" {
 variable "vault_route53_public_dns_name" {
   description = "The Route53 public DNS name for the vault ELB. If not set, no Route53 record will be created."
   default     = ""
-}
-
-# -------------------------------------------------------------------------------------------------
-# Instances (required)
-# -------------------------------------------------------------------------------------------------
-variable "ssh_keys" {
-  description = "A list of public ssh keys to add to authorized_keys files."
-  type        = "list"
 }
 
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the bundled example and makes it work out of the box.

## Usage

```bash
$ cd examples/custom-vpc-with-vault
$ terraform init
$ terraform apply
```

## Tagging

Once merged, this will increment the hotfix version of the tag, so it will end up `v0.2.1`