### PR TITLE
OPS-2684 S3 backend (with optional KMS encryption)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+---
+
+###
+### Travis settings
+###
+sudo: required
+services:
+  - docker
+
+
+###
+### Installation
+###
+before_install: true
+install: true
+
+###
+### Linting
+###
+before_script:
+  - make lint
+
+
+###
+### Testing
+###
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,12 @@ test:
 		echo "################################################################################"; \
 		echo "# Terraform init: $(example)"; \
 		echo "################################################################################"; \
-		docker run -it --rm -v "$(CURRENT_DIR):/t" hashicorp/terraform:light \
-			init -verify-plugins=true -lock=false -input=false -get-plugins=true -get=true /t/$(example); \
+		if docker run -it --rm -v "$(CURRENT_DIR):/t" hashicorp/terraform:light \
+			init -verify-plugins=true -lock=false -input=false -get-plugins=true -get=true /t/$(example); then \
+			echo "OK"; \
+		else \
+			echo "Failed"; \
+			exit 1; \
+		fi; \
 		echo; \
 	)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+CURRENT_DIR = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+EXAMPLE_DIR = $(sort $(dir $(wildcard examples/*/)))
+
+
+help:
+	@echo "lint       Static source code analysis"
+	@echo "test       Integration tests"
+
+lint:
+	@# Lint all Terraform files
+	@echo "################################################################################"
+	@echo "# Terraform fmt"
+	@echo "################################################################################"
+	@if docker run -it --rm -v "$(CURRENT_DIR)/terraform:/t:ro" hashicorp/terraform:light \
+		fmt -check=true -diff=true -write=false -list=true /t; then \
+		echo "OK"; \
+	else \
+		echo "Failed"; \
+		exit 1; \
+	fi;
+	@echo
+
+test:
+	@# Test Initialization of all Terraform projects
+	@$(foreach example,\
+		$(EXAMPLE_DIR),\
+		echo "################################################################################"; \
+		echo "# Terraform init: $(example)"; \
+		echo "################################################################################"; \
+		docker run -it --rm -v "$(CURRENT_DIR):/t" hashicorp/terraform:light \
+			init -verify-plugins=true -lock=false -input=false -get-plugins=true -get=true /t/$(example); \
+		echo; \
+	)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ module "aws_vault" {
 | vault_cluster_size | The number of Vault server nodes to deploy. We strongly recommend using 3 or 5. | string | `3` | no |
 | ssh_security_group_id | Security group ID of a bastion (or other EC2 instance) from which you will be allowed to ssh into Vault and Consul. | string | - | yes |
 | vault_ingress_cidr_https | List of CIDR's from which you are allowed to https access the vault cluster. | list | `<list>` | no |
+| enable_s3_backend | Whether to configure an S3 storage backend in the same region in addition to Consul. | string | `false` | no |
+| s3_bucket_name | The name of the S3 bucket in the same region to use as a storage backend. Only used if 'enable_s3_backend' is set to true. | string | `` | no |
+| enable_s3_backend_encryption | Whether to configure the S3 storage backend to be encrypted with a KMS key. | string | `false` | no |
+| kms_alias_name | The name of the KMS key that is used for S3 storage backend encryption. | string | `` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Terraform Module: HashiCorp Vault
 
+[![Build Status](https://travis-ci.com/Flaconi/terraform-aws-vault.svg?branch=master)](https://travis-ci.com/Flaconi/terraform-aws-vault)
 [![Tag](https://img.shields.io/github/tag/Flaconi/terraform-aws-vault.svg)](https://github.com/Flaconi/terraform-aws-vault/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,10 @@ module "vault_cluster" {
   enable_s3_backend = "${var.enable_s3_backend}"
   s3_bucket_name    = "${var.s3_bucket_name}"
 
+  # Encrypt S3 Storage Backend?
+  enable_s3_backend_encryption = "${var.enable_s3_backend_encryption}"
+  kms_alias_name               = "${var.kms_alias_name}"
+
   # Do NOT use the ELB for the ASG health check, or the ASG will assume all sealed instances are
   # unhealthy and repeatedly try to redeploy them.
   # The ELB health check does not work on unsealed Vault instances.

--- a/modules/vault-cluster/README.md
+++ b/modules/vault-cluster/README.md
@@ -36,6 +36,8 @@ into a single 'aws_security_group' block.
 | tags | Tags to attach to all AWS resources | map | `<map>` | no |
 | enable_s3_backend | Whether to configure an S3 storage backend in addition to Consul. | string | `false` | no |
 | s3_bucket_name | The name of the S3 bucket in the same region to use as a storage backend. Only used if 'enable_s3_backend' is set to true. | string | `` | no |
+| enable_s3_backend_encryption | Whether to configure the S3 storage backend to be encrypted with a KMS key. | string | `false` | no |
+| kms_alias_name | The name of the KMS key that is used for S3 storage backend encryption. | string | `` | no |
 
 ## Outputs
 

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -125,3 +125,13 @@ variable "s3_bucket_name" {
   description = "The name of the S3 bucket in the same region to use as a storage backend. Only used if 'enable_s3_backend' is set to true."
   default     = ""
 }
+
+variable "enable_s3_backend_encryption" {
+  description = "Whether to configure the S3 storage backend to be encrypted with a KMS key."
+  default     = false
+}
+
+variable "kms_alias_name" {
+  description = "The name of the KMS key that is used for S3 storage backend encryption."
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -103,3 +103,13 @@ variable "s3_bucket_name" {
   description = "The name of the S3 bucket in the same region to use as a storage backend. Only used if 'enable_s3_backend' is set to true."
   default     = ""
 }
+
+variable "enable_s3_backend_encryption" {
+  description = "Whether to configure the S3 storage backend to be encrypted with a KMS key."
+  default     = false
+}
+
+variable "kms_alias_name" {
+  description = "The name of the KMS key that is used for S3 storage backend encryption."
+  default     = ""
+}


### PR DESCRIPTION
# Optional S3 backend with KMS encryption

This PR adds the feature to specify an optional S3 backend also with optional KMS encryption:

S3 bucket name and KMS alias name must already exist and their names must be specified in order to be enabled. By making use of this external storage backend the current module will be 100% stateless and independent of any Vault stored data. This also makes it possible to destroy and re-deploy Vault without losing any data

Additionally basic Travis-CI tests are added:

* `terraform fmt`
* `terraform init` (for bundled example)

## Tagging

After merging git must be tagged with `v0.3.0` as new features have been added

## Additional notes

This PR is the successor of https://github.com/Flaconi/terraform-aws-vault/pull/6 which had wrong branch name and commit messages