### PR TITLE
Allows for multiple SGs IDs to be used for ingress rules

### DIFF
--- a/examples/custom-vpc-with-vault/main.tf
+++ b/examples/custom-vpc-with-vault/main.tf
@@ -39,6 +39,6 @@ module "aws_vault" {
 
   # Security
   ssh_keys                 = ["ssh-ed25519 AAAAC3Nznte5aaCdi1a1Lzaai/tX6Mc2E+S6g3lrClL09iBZ5cW2OZdSIqomcMko 2 mysshkey"]
-  ssh_security_group_id    = "${module.aws_vpc.bastion_security_group_id}"
+  ssh_security_group_ids   = ["${module.aws_vpc.bastion_security_group_id}"]
   vault_ingress_cidr_https = ["0.0.0.0/0"]
 }

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ module "vault_cluster" {
   # Security groups
   elb_security_group_id    = "${module.vault_elb.security_group_id}"
   consul_security_group_id = "${module.consul_cluster.security_group_id}"
-  ssh_security_group_id    = "${var.ssh_security_group_id}"
+  ssh_security_group_ids   = "${var.ssh_security_group_ids}"
 
   tags = "${var.tags}"
 }
@@ -185,7 +185,7 @@ module "consul_cluster" {
 
   # Security groups
   vault_security_group_id = "${module.vault_cluster.security_group_id}"
-  ssh_security_group_id   = "${var.ssh_security_group_id}"
+  ssh_security_group_ids  = "${var.ssh_security_group_ids}"
 
   # The EC2 Instances will use these tags to automatically discover each other and form a cluster
   cluster_tag_key   = "${local.consul_cluster_tag_key}"

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -313,7 +313,7 @@ resource "aws_security_group" "lc_security_group" {
     from_port       = "22"
     to_port         = "22"
     protocol        = "tcp"
-    security_groups = ["${var.ssh_security_group_id}"]
+    security_groups = ["${var.ssh_security_group_ids}"]
     description     = "External SSH. Allow SSH access to Consul instances from this security group (from ELB or instance)."
   }
 

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -89,8 +89,9 @@ variable "instance_profile_path" {
 # -------------------------------------------------------------------------------------------------
 # Security groups (required)
 # -------------------------------------------------------------------------------------------------
-variable "ssh_security_group_id" {
-  description = "ID of the security group of a bastion ssh instance from where you can ssh into the Consul instances."
+variable "ssh_security_group_ids" {
+  description = "IDs of the security groups of a bastion ssh instance from where you can ssh into the Consul instances."
+  type        = "list"
 }
 
 variable "vault_security_group_id" {

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -227,7 +227,7 @@ resource "aws_security_group" "lc_security_group" {
     from_port       = "22"
     to_port         = "22"
     protocol        = "tcp"
-    security_groups = ["${var.ssh_security_group_id}"]
+    security_groups = ["${var.ssh_security_group_ids}"]
     description     = "External SSH. Allow SSH access to Vault instances from this security group (from ELB or instance)."
   }
 

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -89,8 +89,9 @@ variable "elb_security_group_id" {
   description = "ID of the security group of a public ELB from which you can API access the Vault instances."
 }
 
-variable "ssh_security_group_id" {
-  description = "ID of the security group of a bastion ssh instance from where you can ssh into the Vault instances."
+variable "ssh_security_group_ids" {
+  description = "IDs of the security groups of a bastion ssh instance from where you can ssh into the Vault instances."
+  type        = "list"
 }
 
 variable "consul_security_group_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -81,8 +81,9 @@ variable "vault_cluster_size" {
 # -------------------------------------------------------------------------------------------------
 # Security
 # -------------------------------------------------------------------------------------------------
-variable "ssh_security_group_id" {
-  description = "Security group ID of a bastion (or other EC2 instance) from which you will be allowed to ssh into Vault and Consul."
+variable "ssh_security_group_ids" {
+  description = "Security group IDs of a bastion (or other EC2 instance) from which you will be allowed to ssh into Vault and Consul."
+  type        = "list"
 }
 
 variable "vault_ingress_cidr_https" {


### PR DESCRIPTION
As the name in the ingress block already hints (`security_groups`), this allows the usage of a list of IDs rather than a single SG ID.

Upcoming release tag: `v0.3.3`