### PR TITLE
Corrects vars type

### DIFF
--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -7,7 +7,7 @@ variable "vpc_id" {
 
 variable "subnet_ids" {
   description = "The subnet IDs into which the EC2 Instances should be deployed. You should typically pass in one subnet ID per node in the cluster_size variable. We strongly recommend that you run Vault in private subnets. At least one of var.subnet_ids or var.availability_zones must be non-empty."
-  type        = list(string)
+  type        = list
 }
 
 # -------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -7,12 +7,12 @@ variable "vpc_id" {
 
 variable "public_subnet_ids" {
   description = "A list of public subnet IDs into which the Vault ELB will be provisioned."
-  type        = list(string)
+  type        = list
 }
 
 variable "private_subnet_ids" {
   description = "A list of private subnet IDs into which Vault and Consul will be provisioned."
-  type        = list(string)
+  type        = list
 }
 
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes error:

```
Error: Invalid value for module argument

  on main.tf line 82, in module "aws_vault":
  82:   public_subnet_ids  = module.aws_vpc.public_subnets

The given value is not suitable for child module variable "public_subnet_ids"
defined at .terraform/modules/aws_vault/variables.tf:8,1-29: element 0: string
required.


Error: Invalid value for module argument

  on main.tf line 83, in module "aws_vault":
  83:   private_subnet_ids = module.aws_vpc.private_subnets

The given value is not suitable for child module variable "private_subnet_ids"
defined at .terraform/modules/aws_vault/variables.tf:13,1-30: element 0:
string required.
```