### PR TITLE
Prevents instances to be removed from the ELB

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -46,6 +46,12 @@ resource "aws_autoscaling_group" "autoscaling_group" {
     ],
     local.tags_asg_format,
   )
+
+  lifecycle {
+    ignore_changes = [
+      load_balancers,
+    ]
+  }
 }
 
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Upcoming release: `v1.0.1`

The explanation for this is provided in the 1st note block on the resource documentation page: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group

The attachment itself is handled here: https://github.com/Flaconi/terraform-aws-vault/blob/master/main.tf#L158