### PR TITLE
Fixes Vault nodes access issue due to missing SGs

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -29,6 +29,12 @@ resource "aws_autoscaling_group" "autoscaling_group" {
     ],
     local.tags_asg_format,
   )
+
+  lifecycle {
+    ignore_changes = [
+      load_balancers,
+    ]
+  }
 }
 
 resource "aws_launch_configuration" "launch_configuration" {

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -41,6 +41,13 @@ resource "aws_launch_configuration" "launch_configuration" {
   iam_instance_profile = aws_iam_instance_profile.instance_profile.name
   placement_tenancy    = var.tenancy
 
+  security_groups = [
+    module.lc_security_group.security_group_id,
+    module.attach_security_group.security_group_id,
+  ]
+
+  associate_public_ip_address = false
+
   ebs_optimized = var.root_volume_ebs_optimized
   root_block_device {
     volume_type           = var.root_volume_type


### PR DESCRIPTION
Without this fix, the Vault cluster nodes are spawned with only the `default`
SG which makes them inaccessible.

Upcoming release: `v2.0.1`